### PR TITLE
Use only lower 16bit of lp_ticker as minar clock

### DIFF
--- a/minar-platform/minar_platform_types.h
+++ b/minar-platform/minar_platform_types.h
@@ -30,7 +30,7 @@ enum Constants{
 
 #if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
     // use only lower 16bits of timer for testing timer overflow
-	Time_Mask = YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
+    Time_Mask = YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
 #else
     // 32 bits of time for mbed platforms
     Time_Mask = 0xFFFFFFFFu

--- a/minar-platform/minar_platform_types.h
+++ b/minar-platform/minar_platform_types.h
@@ -42,6 +42,13 @@ typedef uint32_t irqstate_t;
 // Internal time type
 typedef uint32_t tick_t;
 
+namespace test {
+#if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
+    uint32_t *get_sleep_until_buf(void);
+    uint32_t get_sleep_until_buf_tail(void);
+#endif
+}; // namespace test
+
 }; // namespace platform
 }; // namespace minar
 

--- a/minar-platform/minar_platform_types.h
+++ b/minar-platform/minar_platform_types.h
@@ -29,9 +29,8 @@ enum Constants{
     Time_Base = MINAR_PLATFORM_TIME_BASE,
 
 #if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
-#warning "testing clock overflow"
     // use only lower 16bits of timer for testing timer overflow
-	Time_Mask = UINT32_MAX >> 16
+	Time_Mask = YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
 #else
     // 32 bits of time for mbed platforms
     Time_Mask = 0xFFFFFFFFu

--- a/minar-platform/minar_platform_types.h
+++ b/minar-platform/minar_platform_types.h
@@ -27,8 +27,15 @@ namespace platform {
 enum Constants{
     // ticks per second (maximum resolution). This is what the OS works with.
     Time_Base = MINAR_PLATFORM_TIME_BASE,
+
+#if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
+#warning "testing clock overflow"
+    // use only lower 16bits of timer for testing timer overflow
+	Time_Mask = UINT32_MAX >> 16
+#else
     // 32 bits of time for mbed platforms
     Time_Mask = 0xFFFFFFFFu
+#endif
 };
 
 typedef uint32_t irqstate_t;

--- a/source/mbed_platform.cpp
+++ b/source/mbed_platform.cpp
@@ -68,6 +68,9 @@ uint32_t getTimeOverflows(){
 void sleepFromUntil(tick_t now, tick_t until){
 
 #if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
+    /* only lower bits of the timer is passed to this function
+     * in order to set the correct sleeping time in the underlying timer,
+     * the full time (with the top bits) have to be reconstructed here.*/
     tick_t timer_top_bits = lp_ticker_read() & ~Time_Mask;
     now += timer_top_bits;
     until += timer_top_bits;

--- a/source/mbed_platform.cpp
+++ b/source/mbed_platform.cpp
@@ -39,6 +39,8 @@ namespace platform {
 namespace test {
 #if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
     #define BUFFER_SIZE 128
+    #define ERROR_BUFFER_FULL UINT32_MAX
+
     static uint32_t sleep_until_buf[BUFFER_SIZE];
     static uint32_t sleep_until_buf_tail = 0;
 
@@ -54,7 +56,7 @@ namespace test {
         if (sleep_until_buf_tail < BUFFER_SIZE-1) {
             return ++sleep_until_buf_tail;
         } else {
-            return -1;
+            return ERROR_BUFFER_FULL;
         }
     }
 #endif

--- a/source/mbed_platform.cpp
+++ b/source/mbed_platform.cpp
@@ -21,6 +21,10 @@
 #include "mbed-hal/sleep_api.h"
 #include "cmsis-core/core_generic.h"
 
+#if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
+#include "stdio.h"
+#endif
+
 /// @name Local Constants
 const static minar::platform::tick_t Minimum_Sleep = MINAR_PLATFORM_MINIMUM_SLEEP; // in Platform_Time_Base units
 
@@ -80,6 +84,8 @@ void sleepFromUntil(tick_t now, tick_t until){
     }
 
     const tick_t real_now = timer_top_bits + getTime();
+
+    printf("sleep From %lx Until %lx real_now %lx\r\n", now, until, real_now);
 #else
     // use real-now for front-most end of do-not-sleep range check
     const tick_t real_now = getTime();

--- a/source/mbed_platform.cpp
+++ b/source/mbed_platform.cpp
@@ -21,6 +21,10 @@
 #include "mbed-hal/sleep_api.h"
 #include "cmsis-core/core_generic.h"
 
+#if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
+#include "mbed-drivers/test_env.h"
+#endif
+
 /// @name Local Constants
 const static minar::platform::tick_t Minimum_Sleep = MINAR_PLATFORM_MINIMUM_SLEEP; // in Platform_Time_Base units
 
@@ -53,7 +57,11 @@ void sleep(){
 }
 
 tick_t getTime() {
+#if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
+    return lp_ticker_read() & Time_Mask;
+#else
     return lp_ticker_read();
+#endif
 }
 
 uint32_t getTimeOverflows(){
@@ -61,8 +69,24 @@ uint32_t getTimeOverflows(){
 }
 
 void sleepFromUntil(tick_t now, tick_t until){
+
+#if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
+    MBED_HOSTTEST_ASSERT(now <= Time_Mask && until <= Time_Mask);
+    tick_t timer_top_bits = lp_ticker_read() & ~Time_Mask;
+    now += timer_top_bits;
+    until += timer_top_bits;
+
+    if (until < now) {
+        until += Time_Mask;
+    }
+
+    const tick_t real_now = timer_top_bits + getTime();
+    //printf("sleepFromUntil %lx %lx real_now %lx\r\n", now, until, real_now);
+#else
     // use real-now for front-most end of do-not-sleep range check
     const tick_t real_now = getTime();
+#endif
+
     if(timeIsInPeriod(now, until, real_now + Minimum_Sleep)){
         // in this case too soon to go to sleep, just return
         return;

--- a/source/mbed_platform.cpp
+++ b/source/mbed_platform.cpp
@@ -51,7 +51,11 @@ namespace test {
     }
 
     uint32_t inc_sleep_until_buf_tail(void) {
-        return ++sleep_until_buf_tail;
+        if (sleep_until_buf_tail < BUFFER_SIZE-1) {
+            return ++sleep_until_buf_tail;
+        } else {
+            return -1;
+        }
     }
 #endif
 }; // namespace test

--- a/source/mbed_platform.cpp
+++ b/source/mbed_platform.cpp
@@ -21,10 +21,6 @@
 #include "mbed-hal/sleep_api.h"
 #include "cmsis-core/core_generic.h"
 
-#if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
-#include "mbed-drivers/test_env.h"
-#endif
-
 /// @name Local Constants
 const static minar::platform::tick_t Minimum_Sleep = MINAR_PLATFORM_MINIMUM_SLEEP; // in Platform_Time_Base units
 
@@ -58,6 +54,7 @@ void sleep(){
 
 tick_t getTime() {
 #if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
+    #warning "testing clock overflow"
     return lp_ticker_read() & Time_Mask;
 #else
     return lp_ticker_read();
@@ -71,7 +68,6 @@ uint32_t getTimeOverflows(){
 void sleepFromUntil(tick_t now, tick_t until){
 
 #if YOTTA_CFG_MINAR_TEST_CLOCK_OVERFLOW
-    MBED_HOSTTEST_ASSERT(now <= Time_Mask && until <= Time_Mask);
     tick_t timer_top_bits = lp_ticker_read() & ~Time_Mask;
     now += timer_top_bits;
     until += timer_top_bits;
@@ -81,7 +77,6 @@ void sleepFromUntil(tick_t now, tick_t until){
     }
 
     const tick_t real_now = timer_top_bits + getTime();
-    //printf("sleepFromUntil %lx %lx real_now %lx\r\n", now, until, real_now);
 #else
     // use real-now for front-most end of do-not-sleep range check
     const tick_t real_now = getTime();


### PR DESCRIPTION
In order to create timer overflow faster. Used for
minar testing. @bogdanm Please review.