### PR TITLE
Port tests to async model

### DIFF
--- a/module.json
+++ b/module.json
@@ -32,6 +32,9 @@
     "mbed-hal": "^1.0.0",
     "minar": "*"
   },
+  "testDependencies": {
+    "greentea-client": "~0.1.4"
+  },
   "keywords": [
     "mbed",
     "mbed-official"

--- a/test/platform_test/main.cpp
+++ b/test/platform_test/main.cpp
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed/test_env.h"
+#include "mbed-drivers/mbed.h"
+#include "greentea-client/test_env.h"
 #include "us_ticker_api.h"
 #include "minar-platform/minar_platform.h"
 
@@ -32,10 +33,7 @@ static tick_t sleep_until(tick_t ticks)
 
 void app_start(int, char*[])
 {
-    MBED_HOSTTEST_TIMEOUT(10);
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_DESCRIPTION(minar mbed platform);
-    MBED_HOSTTEST_START("minar mbed platform");
+    GREENTEA_SETUP(10, "default_auto");
 
     const char *current_test = "none";
     bool tests_pass = false;
@@ -125,5 +123,5 @@ void app_start(int, char*[])
         printf("First failing test: %s \r\n", current_test);
     }
 
-    MBED_HOSTTEST_RESULT(tests_pass);
+    GREENTEA_TESTSUITE_RESULT(tests_pass);
 }


### PR DESCRIPTION
Test reults from ```mbedgt -VS```:
```
mbedgt: test suite report:
+---------------+---------------+----------------------------------------+--------+--------------------+-------------+
| target        | platform_name | test suite                             | result | elapsed_time (sec) | copy_method |
+---------------+---------------+----------------------------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | minar-platform-mbed-test-platform_test | OK     | 9.79               | shell       |
+---------------+---------------+----------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+---------------+---------------+----------------------------------------+---------------+--------+--------+--------+--------------------+
| target        | platform_name | test suite                             | test case     | passed | failed | result | elapsed_time (sec) |
+---------------+---------------+----------------------------------------+---------------+--------+--------+--------+--------------------+
| frdm-k64f-gcc | K64F          | minar-platform-mbed-test-platform_test | platform_test | 1      | 0      | OK     | 9.79               |
+---------------+---------------+----------------------------------------+---------------+--------+--------+--------+--------------------+
mbedgt: test case results: 1 OK
mbedgt: completed in 10.83 sec
```
```
$yt ls
minar-platform-mbed 1.1.3
|_ cmsis-core 1.1.2
| \_ cmsis-core-freescale 1.0.0 yotta_modules\cmsis-core-freescale
|   \_ cmsis-core-k64f 1.0.0 yotta_modules\cmsis-core-k64f
|_ mbed-hal 1.2.2
| |_ mbed-drivers 1.3.0 yotta_modules\mbed-drivers
| | |_ ualloc 1.1.0 yotta_modules\ualloc
| | | \_ dlmalloc 1.0.0 yotta_modules\dlmalloc
| | |_ core-util 1.6.0 yotta_modules\core-util
| | \_ compiler-polyfill 1.2.1 yotta_modules\compiler-polyfill
| \_ mbed-hal-freescale 1.0.0 yotta_modules\mbed-hal-freescale
|   \_ mbed-hal-ksdk-mcu 1.1.0 yotta_modules\mbed-hal-ksdk-mcu
|     |_ uvisor-lib 2.0.0 yotta_modules\uvisor-lib
|     \_ mbed-hal-k64f 1.2.0 yotta_modules\mbed-hal-k64f
|       \_ mbed-hal-frdm-k64f 1.0.2 yotta_modules\mbed-hal-frdm-k64f
|_ minar 1.1.0
| \_ minar-platform 1.0.0 yotta_modules\minar-platform
\_ greentea-client 0.1.8 (test dependency)
```